### PR TITLE
Optimize mem_replace exercise

### DIFF
--- a/2_idioms/2_2_mem_replace/src/main.rs
+++ b/2_idioms/2_2_mem_replace/src/main.rs
@@ -19,14 +19,10 @@ struct Trinity<T> {
     c: T,
 }
 
-impl<T: Clone> Trinity<T> {
+impl<T> Trinity<T> {
     fn rotate(&mut self) {
-        let a = self.a.clone();
-        let b = self.b.clone();
-        let c = self.c.clone();
-        self.a = b;
-        self.b = c;
-        self.c = a;
+        std::mem::swap(&mut self.a, &mut self.b);
+        std::mem::swap(&mut self.b, &mut self.c);
     }
 }
 
@@ -36,18 +32,19 @@ struct Solver<T> {
     unsolved: Vec<Trinity<T>>,
 }
 
-impl<T: Clone + PartialEq> Solver<T> {
+impl<T: PartialEq> Solver<T> {
     fn resolve(&mut self) {
-        let mut unsolved = Vec::with_capacity(self.unsolved.len());
-        'l: for t in self.unsolved.iter_mut() {
+        let expected = &self.expected;
+        let mut unsolved = std::mem::take(&mut self.unsolved);
+        unsolved.retain_mut(|t| {
             for _ in 0..3 {
-                if *t == self.expected {
-                    continue 'l;
+                if t == expected {
+                    return false;
                 }
                 t.rotate();
             }
-            unsolved.push(t.clone())
-        }
+            true
+        });
         self.unsolved = unsolved;
     }
 }


### PR DESCRIPTION
## Summary
- rotate `Trinity` values using in-place swaps to avoid redundant cloning
- reuse the `unsolved` buffer and retain only unresolved entries without cloning

## Testing
- cargo run -p step_2_2

------
https://chatgpt.com/codex/tasks/task_e_68f9fe3bfe30832b9d76b21f412c2e05