### PR TITLE
Seal iterator extension trait and guard MyError::type_id

### DIFF
--- a/2_idioms/2_6_sealing/src/lib.rs
+++ b/2_idioms/2_6_sealing/src/lib.rs
@@ -2,3 +2,37 @@ pub mod my_error;
 pub mod my_iterator_ext;
 
 pub use self::{my_error::MyError, my_iterator_ext::MyIteratorExt};
+
+// The trait below is sealed and cannot be implemented here.
+// struct LocalIterator;
+//
+// impl Iterator for LocalIterator {
+//     type Item = ();
+//
+//     fn next(&mut self) -> Option<Self::Item> {
+//         None
+//     }
+// }
+//
+// impl MyIteratorExt for LocalIterator {}
+
+// The hidden method of this trait is sealed and cannot be overridden here.
+// use std::fmt;
+//
+// #[derive(Debug)]
+// struct LocalError;
+//
+// impl fmt::Display for LocalError {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         write!(f, "local error")
+//     }
+// }
+//
+// impl MyError for LocalError {
+//     fn type_id(&self) -> std::any::TypeId
+//     where
+//         Self: 'static,
+//     {
+//         std::any::TypeId::of::<()>()
+//     }
+// }

--- a/2_idioms/2_6_sealing/src/my_error.rs
+++ b/2_idioms/2_6_sealing/src/my_error.rs
@@ -66,8 +66,34 @@ pub trait MyError: Debug + Display {
     /// Gets the `TypeId` of `self`.
     ///
     /// __This is memory-unsafe to override in user code.__
+    ///
+    /// This method is sealed outside of this module.
     #[doc(hidden)]
-    fn type_id(&self) -> TypeId
+    ///
+    /// ```compile_fail
+    /// use std::fmt;
+    ///
+    /// use step_2_6::MyError;
+    ///
+    /// #[derive(Debug)]
+    /// struct CustomError;
+    ///
+    /// impl fmt::Display for CustomError {
+    ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    ///         write!(f, "custom error")
+    ///     }
+    /// }
+    ///
+    /// impl MyError for CustomError {
+    ///     fn type_id(&self) -> std::any::TypeId
+    ///     where
+    ///         Self: 'static,
+    ///     {
+    ///         std::any::TypeId::of::<()>()
+    ///     }
+    /// }
+    /// ```
+    fn type_id(&self, _: private::Token) -> TypeId
     where
         Self: 'static,
     {
@@ -79,4 +105,9 @@ impl<'a, T: MyError + ?Sized> MyError for &'a T {
     fn source(&self) -> Option<&(dyn MyError + 'static)> {
         MyError::source(&**self)
     }
+}
+
+mod private {
+    #[derive(Clone, Copy, Default)]
+    pub struct Token;
 }

--- a/2_idioms/2_6_sealing/src/my_iterator_ext.rs
+++ b/2_idioms/2_6_sealing/src/my_iterator_ext.rs
@@ -25,7 +25,10 @@ use self::format::{Format, FormatWith};
 ///
 /// impl MyIteratorExt for DummyIter {}
 /// ```
-pub trait MyIteratorExt: Iterator + private::Sealed {
+pub trait MyIteratorExt: Iterator {
+    #[doc(hidden)]
+    type __Seal: private::Sealed;
+
     /// Format all iterator elements, separated by `sep`.
     ///
     /// All elements are formatted (any formatting trait)
@@ -86,12 +89,19 @@ pub trait MyIteratorExt: Iterator + private::Sealed {
     }
 }
 
-impl<T> MyIteratorExt for T where T: Iterator {}
+impl<T> MyIteratorExt for T
+where
+    T: Iterator,
+{
+    type __Seal = private::Token;
+}
 
 mod private {
+    pub struct Token;
+
     pub trait Sealed {}
 
-    impl<T> Sealed for T where T: Iterator {}
+    impl Sealed for Token {}
 }
 
 mod format {

--- a/2_idioms/2_6_sealing/src/my_iterator_ext.rs
+++ b/2_idioms/2_6_sealing/src/my_iterator_ext.rs
@@ -9,7 +9,23 @@ use std::fmt;
 use self::format::{Format, FormatWith};
 
 /// Extension trait for an [`Iterator`].
-pub trait MyIteratorExt: Iterator {
+///
+/// ```compile_fail
+/// use step_2_6::MyIteratorExt;
+///
+/// struct DummyIter;
+///
+/// impl Iterator for DummyIter {
+///     type Item = ();
+///
+///     fn next(&mut self) -> Option<Self::Item> {
+///         None
+///     }
+/// }
+///
+/// impl MyIteratorExt for DummyIter {}
+/// ```
+pub trait MyIteratorExt: Iterator + private::Sealed {
     /// Format all iterator elements, separated by `sep`.
     ///
     /// All elements are formatted (any formatting trait)
@@ -71,6 +87,12 @@ pub trait MyIteratorExt: Iterator {
 }
 
 impl<T> MyIteratorExt for T where T: Iterator {}
+
+mod private {
+    pub trait Sealed {}
+
+    impl<T> Sealed for T where T: Iterator {}
+}
 
 mod format {
     use std::{cell::RefCell, fmt};


### PR DESCRIPTION
## Summary
- add a private sealing supertrait for `MyIteratorExt` and document the downstream implementation failure through compile-fail tests and inline examples
- seal `MyError::type_id` via a private token parameter while documenting failed overrides both in doctests and comments
- provide non-compiling examples in the crate root demonstrating that the seals prevent local implementations

## Testing
- cargo test -p step_2_6

------
https://chatgpt.com/codex/tasks/task_e_690604a3c774832bbb317b8ee4c196f8