### PR TITLE
Implement declarative and procedural btreemap macros

### DIFF
--- a/3_ecosystem/3_2_macro/Cargo.toml
+++ b/3_ecosystem/3_2_macro/Cargo.toml
@@ -3,3 +3,6 @@ name = "step_3_2"
 version = "0.1.0"
 edition = "2024"
 publish = false
+
+[dependencies]
+btreemap_proc_macro = { path = "btreemap_proc_macro" }

--- a/3_ecosystem/3_2_macro/btreemap_proc_macro/Cargo.toml
+++ b/3_ecosystem/3_2_macro/btreemap_proc_macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "btreemap_proc_macro"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/3_ecosystem/3_2_macro/btreemap_proc_macro/src/lib.rs
+++ b/3_ecosystem/3_2_macro/btreemap_proc_macro/src/lib.rs
@@ -1,0 +1,58 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Expr, Token, parse_macro_input};
+
+struct MapEntries {
+    pairs: Punctuated<MapEntry, Token![,]>,
+}
+
+impl Parse for MapEntries {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let pairs = if input.is_empty() {
+            Punctuated::new()
+        } else {
+            Punctuated::parse_terminated(input)?
+        };
+
+        Ok(Self { pairs })
+    }
+}
+
+struct MapEntry {
+    key: Expr,
+    value: Expr,
+}
+
+impl Parse for MapEntry {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let key: Expr = input.parse()?;
+        input.parse::<Token![=>]>()?;
+        let value: Expr = input.parse()?;
+
+        Ok(Self { key, value })
+    }
+}
+
+#[proc_macro]
+pub fn btreemap(tokens: TokenStream) -> TokenStream {
+    let entries = parse_macro_input!(tokens as MapEntries);
+
+    if entries.pairs.is_empty() {
+        return quote!(::std::collections::BTreeMap::new()).into();
+    }
+
+    let inserts = entries.pairs.iter().map(|entry| {
+        let MapEntry { key, value } = entry;
+        quote! {
+            map.insert(#key, #value);
+        }
+    });
+
+    TokenStream::from(quote! {{
+        let mut map = ::std::collections::BTreeMap::new();
+        #(#inserts)*
+        map
+    }})
+}

--- a/3_ecosystem/3_2_macro/src/lib.rs
+++ b/3_ecosystem/3_2_macro/src/lib.rs
@@ -1,0 +1,60 @@
+//! Helper macros for building [`BTreeMap`](std::collections::BTreeMap) values.
+//!
+//! The crate exposes two variants of the `btreemap!` macro:
+//! - [`btreemap`] – implemented using `macro_rules!`.
+//! - [`proc_btreemap`] – implemented as a procedural macro located in the
+//!   companion [`btreemap_proc_macro`] crate.
+//!
+//! Both macros accept the same syntax and return a populated
+//! [`BTreeMap`](std::collections::BTreeMap) instance.
+
+/// Declarative implementation of the [`btreemap!`] macro.
+#[macro_export]
+macro_rules! btreemap {
+    () => {
+        ::std::collections::BTreeMap::new()
+    };
+    ( $( $key:expr => $value:expr ),+ $(,)? ) => {{
+        let mut map = ::std::collections::BTreeMap::new();
+        $(
+            map.insert($key, $value);
+        )+
+        map
+    }};
+}
+
+pub use btreemap_proc_macro::btreemap as proc_btreemap;
+
+#[cfg(test)]
+mod tests {
+    use super::proc_btreemap;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn declarative_macro_builds_map() {
+        let map = btreemap! {
+            "a" => 1,
+            "b" => 2,
+        };
+
+        let mut expected = BTreeMap::new();
+        expected.insert("a", 1);
+        expected.insert("b", 2);
+
+        assert_eq!(map, expected);
+    }
+
+    #[test]
+    fn procedural_macro_builds_map() {
+        let map = proc_btreemap! {
+            "a" => 1,
+            "b" => 2,
+        };
+
+        let mut expected = BTreeMap::new();
+        expected.insert("a", 1);
+        expected.insert("b", 2);
+
+        assert_eq!(map, expected);
+    }
+}

--- a/3_ecosystem/3_2_macro/src/main.rs
+++ b/3_ecosystem/3_2_macro/src/main.rs
@@ -1,3 +1,18 @@
+use std::collections::BTreeMap;
+
+use step_3_2::{btreemap, proc_btreemap};
+
 fn main() {
-    println!("Implement me!");
+    let declarative: BTreeMap<_, _> = btreemap! {
+        "rust" => "awesome",
+        "macros" => "powerful",
+    };
+
+    let procedural: BTreeMap<_, _> = proc_btreemap! {
+        "rust" => "fearless",
+        "macros" => "expressive",
+    };
+
+    println!("Declarative macro output: {declarative:?}");
+    println!("Procedural macro output: {procedural:?}");
 }


### PR DESCRIPTION
## Summary
- add a declarative `btreemap!` macro and tests for building `BTreeMap` instances
- introduce a companion procedural macro crate providing the same `btreemap!` syntax
- update the step binary to showcase both macro implementations

## Testing
- cargo test -p step_3_2

------
https://chatgpt.com/codex/tasks/task_e_6909b2b272c0832ba83c7f5af3bea6aa