### PR TITLE
Implement format spec parser

### DIFF
--- a/3_ecosystem/3_4_regex_parsing/Cargo.toml
+++ b/3_ecosystem/3_4_regex_parsing/Cargo.toml
@@ -3,3 +3,7 @@ name = "step_3_4"
 version = "0.1.0"
 edition = "2024"
 publish = false
+
+[dependencies]
+once_cell = "1.19"
+regex = "1.10"

--- a/3_ecosystem/3_4_regex_parsing/src/main.rs
+++ b/3_ecosystem/3_4_regex_parsing/src/main.rs
@@ -1,9 +1,143 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
 fn main() {
-    println!("Implement me!");
+    println!("Use `parse` or `parse_with_regex` from tests");
 }
 
 fn parse(input: &str) -> (Option<Sign>, Option<usize>, Option<Precision>) {
-    unimplemented!()
+    parse_manual(input)
+}
+
+fn parse_manual(input: &str) -> (Option<Sign>, Option<usize>, Option<Precision>) {
+    let chars: Vec<char> = input.chars().collect();
+    let mut index = 0;
+
+    if chars
+        .get(index + 1)
+        .is_some_and(|c| matches!(c, '<' | '^' | '>'))
+    {
+        index += 2;
+    } else if chars
+        .get(index)
+        .is_some_and(|c| matches!(c, '<' | '^' | '>'))
+    {
+        index += 1;
+    }
+
+    let sign = chars.get(index).and_then(|c| match c {
+        '+' => {
+            index += 1;
+            Some(Sign::Plus)
+        }
+        '-' => {
+            index += 1;
+            Some(Sign::Minus)
+        }
+        _ => None,
+    });
+
+    if chars.get(index) == Some(&'#') {
+        index += 1;
+    }
+
+    if chars.get(index) == Some(&'0') {
+        index += 1;
+    }
+
+    let width = {
+        let start = index;
+        while chars.get(index).is_some_and(|c| c.is_ascii_digit()) {
+            index += 1;
+        }
+
+        if start == index {
+            None
+        } else {
+            let value = chars[start..index].iter().collect::<String>().parse().ok();
+
+            if chars.get(index) == Some(&'$') {
+                index += 1;
+            }
+
+            value
+        }
+    };
+
+    let precision = if chars.get(index) == Some(&'.') {
+        index += 1;
+        match chars.get(index) {
+            Some('*') => {
+                index += 1;
+                Some(Precision::Asterisk)
+            }
+            Some(c) if c.is_ascii_digit() => {
+                let start = index;
+                while chars.get(index).is_some_and(|c| c.is_ascii_digit()) {
+                    index += 1;
+                }
+
+                let digits: Option<usize> =
+                    chars[start..index].iter().collect::<String>().parse().ok();
+
+                let result = if chars.get(index) == Some(&'$') {
+                    index += 1;
+                    digits.map(Precision::Argument)
+                } else {
+                    digits.map(Precision::Integer)
+                };
+
+                result
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    (sign, width, precision)
+}
+
+fn parse_with_regex(input: &str) -> (Option<Sign>, Option<usize>, Option<Precision>) {
+    static FORMAT_RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"^(?:.?[<^>])?(?P<sign>[+-])?#?0?(?P<width>\d+(?:\$)?)?(?P<precision>\.(?:\d+(?:\$)?|\*))?")
+            .expect("valid regex")
+    });
+
+    let captures = FORMAT_RE.captures(input);
+
+    let sign = captures
+        .as_ref()
+        .and_then(|caps| caps.name("sign"))
+        .and_then(|m| match m.as_str() {
+            "+" => Some(Sign::Plus),
+            "-" => Some(Sign::Minus),
+            _ => None,
+        });
+
+    let width = captures
+        .as_ref()
+        .and_then(|caps| caps.name("width"))
+        .and_then(|m| m.as_str().trim_end_matches('$').parse().ok());
+
+    let precision = captures
+        .as_ref()
+        .and_then(|caps| caps.name("precision"))
+        .and_then(|m| match &m.as_str()[1..] {
+            "*" => Some(Precision::Asterisk),
+            value => {
+                let trimmed = value.trim_end_matches('$');
+                trimmed.parse().ok().map(|number| {
+                    if value.ends_with('$') {
+                        Precision::Argument(number)
+                    } else {
+                        Precision::Integer(number)
+                    }
+                })
+            }
+        });
+
+    (sign, width, precision)
 }
 
 #[derive(Debug, PartialEq)]
@@ -34,6 +168,8 @@ mod spec {
         ] {
             let (sign, ..) = parse(input);
             assert_eq!(sign, expected);
+            let (sign, ..) = parse_with_regex(input);
+            assert_eq!(sign, expected);
         }
     }
 
@@ -45,8 +181,11 @@ mod spec {
             (">+8.*", Some(8)),
             ("-.1$x", None),
             ("a^#043.8?", Some(43)),
+            ("+1$?", Some(1)),
         ] {
             let (_, width, _) = parse(input);
+            assert_eq!(width, expected);
+            let (_, width, _) = parse_with_regex(input);
             assert_eq!(width, expected);
         }
     }
@@ -59,8 +198,11 @@ mod spec {
             (">+8.*", Some(Precision::Asterisk)),
             ("-.1$x", Some(Precision::Argument(1))),
             ("a^#043.8?", Some(Precision::Integer(8))),
+            ("+1$.2$", Some(Precision::Argument(2))),
         ] {
             let (_, _, precision) = parse(input);
+            assert_eq!(precision, expected);
+            let (_, _, precision) = parse_with_regex(input);
             assert_eq!(precision, expected);
         }
     }


### PR DESCRIPTION
## Summary
- add regex and once_cell dependencies for the format-spec parsing exercise
- implement both manual and regex-based parsers for sign, width, and precision
- expand unit tests to cover both implementations and additional cases

## Testing
- `cargo test -p step_3_4` *(fails: unable to download crates due to 403 CONNECT tunnel error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dca12250c832bb5ce42dd21de98ca)