### PR TITLE
Implement immutable users repository for step 3.5

### DIFF
--- a/3_ecosystem/3_5_collections/Cargo.toml
+++ b/3_ecosystem/3_5_collections/Cargo.toml
@@ -3,3 +3,6 @@ name = "step_3_5"
 version = "0.1.0"
 edition = "2024"
 publish = false
+
+[dependencies]
+im = "15"

--- a/3_ecosystem/3_5_collections/src/main.rs
+++ b/3_ecosystem/3_5_collections/src/main.rs
@@ -1,3 +1,123 @@
-fn main() {
-    println!("Implement me!");
+use im::HashMap;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct User {
+    pub id: u64,
+    pub nickname: String,
+}
+
+pub trait UsersRepository {
+    fn get(&self, id: u64) -> Option<User>;
+    fn get_many<I>(&self, ids: I) -> Vec<User>
+    where
+        I: IntoIterator<Item = u64>;
+    fn search_by_nickname(&self, query: &str) -> Vec<u64>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ImUsersRepository {
+    users: HashMap<u64, User>,
+}
+
+impl ImUsersRepository {
+    pub fn new<U>(users: U) -> Self
+    where
+        U: IntoIterator<Item = User>,
+    {
+        let users_map = users.into_iter().map(|user| (user.id, user)).collect();
+        Self { users: users_map }
+    }
+}
+
+impl UsersRepository for ImUsersRepository {
+    fn get(&self, id: u64) -> Option<User> {
+        self.users.get(&id).cloned()
+    }
+
+    fn get_many<I>(&self, ids: I) -> Vec<User>
+    where
+        I: IntoIterator<Item = u64>,
+    {
+        ids.into_iter()
+            .filter_map(|id| self.users.get(&id).cloned())
+            .collect()
+    }
+
+    fn search_by_nickname(&self, query: &str) -> Vec<u64> {
+        let query = query.to_lowercase();
+        self.users
+            .values()
+            .filter(|user| user.nickname.to_lowercase().contains(&query))
+            .map(|user| user.id)
+            .collect()
+    }
+}
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_repository() -> ImUsersRepository {
+        ImUsersRepository::new([
+            User {
+                id: 1,
+                nickname: "Alice".into(),
+            },
+            User {
+                id: 2,
+                nickname: "Bob".into(),
+            },
+            User {
+                id: 3,
+                nickname: "Alicia".into(),
+            },
+        ])
+    }
+
+    #[test]
+    fn get_returns_exact_user() {
+        let repo = sample_repository();
+
+        let user = repo.get(2);
+
+        assert_eq!(
+            user,
+            Some(User {
+                id: 2,
+                nickname: "Bob".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn get_many_preserves_input_order_and_skips_missing() {
+        let repo = sample_repository();
+
+        let users = repo.get_many([3, 42, 1]);
+
+        assert_eq!(
+            users,
+            vec![
+                User {
+                    id: 3,
+                    nickname: "Alicia".into(),
+                },
+                User {
+                    id: 1,
+                    nickname: "Alice".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn search_by_nickname_is_case_insensitive() {
+        let repo = sample_repository();
+
+        let ids = repo.search_by_nickname("ali");
+
+        assert_eq!(ids, vec![1, 3]);
+    }
 }


### PR DESCRIPTION
## Summary
- add an immutable collection dependency for the step 3.5 crate
- implement a UsersRepository trait with an `im`-backed repository
- cover the repository behaviour with unit tests

## Testing
- cargo fmt -p step_3_5
- cargo test -p step_3_5 *(fails: unable to download crates due to 403 tunnel error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1dc8a6e0832b849771229f67df02)